### PR TITLE
[CPPTemplates] Resolved Ignored Attr Warning in Generated Code

### DIFF
--- a/uxsdcxx/cpp_templates.py
+++ b/uxsdcxx/cpp_templates.py
@@ -182,7 +182,7 @@ inline void attr_error(std::bitset<N> astate, const char * const *lookup, const 
 
 get_line_number_defn = """
 inline void get_line_number(const char *filename, std::ptrdiff_t target_offset, int * line, int * col) {
-	std::unique_ptr<FILE,decltype(&fclose)> f(fopen(filename, "rb"), fclose);
+	std::unique_ptr<FILE,int(*)(FILE*)> f(fopen(filename, "rb"), fclose);
 
 	if (!f) {
 		throw std::runtime_error(std::string("Failed to open file") + filename);


### PR DESCRIPTION
The CPP code generated by uxsdcxx produces a warning in GCC13 due to the decltype passing an attribute into a template argument which is ignored.

See:
https://stackoverflow.com/questions/76867698/what-does-ignoring-attributes-on-template-argument-mean-in-this-context

To simply fix this issue, did not use decltype for the type of the file pointer destructor and just explicitly wrote it out.